### PR TITLE
fix: make home page logo responsive across all screen sizes

### DIFF
--- a/src/components/layout/title.tsx
+++ b/src/components/layout/title.tsx
@@ -28,10 +28,9 @@ const Title = () => {
           height={200}
           unoptimized
           style={{
-            width: "auto",
+            width: "100%",
             height: "auto",
-            maxWidth: 600,
-            maxHeight: 200,
+            maxWidth: "min(600px, 90vw)",
           }}
         />
       </div>


### PR DESCRIPTION
Updated the logo image styling in the Title component to be fully responsive:
- Changed width from "auto" to "100%" to fill container
- Updated maxWidth to use CSS min() function: min(600px, 90vw)
- This ensures the logo never exceeds 600px on large screens
- On smaller screens, it scales down to 90% of viewport width
- Removed fixed maxHeight to maintain proper aspect ratio

Fixes logo overflow issues on mobile devices and tablets.