### PR TITLE
feat: add randomized testimonials section to home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import EventsWorldMap from "@/components/events/EventsWorldMap"
 import Expectations from "@/components/home/expectations"
 import HomeGallery from "@/components/home/gallery"
+import HomeTestimonials from "@/components/home/testimonials"
 import UpcomingEvents from "@/components/home/upcoming"
 import CodeOfConduct from "@/components/layout/codeofconduct"
 import Manifesto from "@/components/layout/manifesto"
@@ -225,6 +226,10 @@ export default function Home() {
 
       <section id="gallery">
         <HomeGallery />
+      </section>
+
+      <section id="testimonials">
+        <HomeTestimonials />
       </section>
 
       <section id="manifesto and code of conduct" className="pt-100">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -62,7 +62,7 @@ export default function Home() {
           and error, play fosters a deeper, more meaningful connection to the
           material being learned.
         </p>
-        <h3 className="pt-100 pb-3">What attend?</h3>
+        <h3 className="pt-100 pb-3">Why attend?</h3>
         <p>
           Whether you are a facilitator, educator, or curious mind, our events
           are designed to spark creativity, foster collaboration, and ignite new
@@ -224,16 +224,8 @@ export default function Home() {
         </p>
       </section>
 
-      <section id="gallery">
-        <HomeGallery />
-      </section>
-
-      <section id="testimonials">
-        <HomeTestimonials />
-      </section>
-
       <section id="manifesto and code of conduct" className="pt-100">
-        <h3 className="pt-100 pb-3">Our values</h3>
+        <h3 className="pt-100 pb-3">What we stand for</h3>
         <p>
           A game/activity at #play14 could be pretty much anything as long as it
           respects our{" "}
@@ -247,6 +239,14 @@ export default function Home() {
             <CodeOfConduct />
           </div>
         </div>
+      </section>
+
+      <section id="testimonials" className="pt-100">
+        <HomeTestimonials />
+      </section>
+
+      <section id="gallery">
+        <HomeGallery />
       </section>
 
       <section id="benefits" className="pt-70">

--- a/src/components/events/EventsWorldMap.scss
+++ b/src/components/events/EventsWorldMap.scss
@@ -14,7 +14,7 @@
   font-weight: bold;
   color: #111827;
 
-  @media (prefers-color-scheme: dark) {
+  [data-theme="dark"] & {
     color: #f3f4f6;
   }
 }
@@ -104,7 +104,7 @@
       0 4px 12px rgba(0, 0, 0, 0.15);
   }
 
-  @media (prefers-color-scheme: dark) {
+  [data-theme="dark"] & {
     background: #1f2937;
     border-color: #374151;
     color: #f3f4f6;
@@ -147,7 +147,7 @@
   &:hover {
     color: #111827;
 
-    @media (prefers-color-scheme: dark) {
+    [data-theme="dark"] & {
       color: #f3f4f6;
     }
   }
@@ -170,7 +170,7 @@
     border-radius: 0.375rem;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
 
-    @media (prefers-color-scheme: dark) {
+    [data-theme="dark"] & {
       background: rgba(31, 41, 55, 0.95);
       color: #9ca3af;
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
@@ -191,7 +191,7 @@
     border-radius: 0.375rem;
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
 
-    @media (prefers-color-scheme: dark) {
+    [data-theme="dark"] & {
       background: rgba(31, 41, 55, 0.95);
       color: #f87171;
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
@@ -235,7 +235,7 @@
   color: #111827;
   margin-right: 0.5rem;
 
-  @media (prefers-color-scheme: dark) {
+  [data-theme="dark"] & {
     color: #f3f4f6;
   }
 }
@@ -271,7 +271,7 @@
   // Use transform for better scaling with browser zoom
   transform-origin: top left;
 
-  @media (prefers-color-scheme: dark) {
+  [data-theme="dark"] & {
     background: #1f2937;
     border-color: #374151;
   }
@@ -300,7 +300,7 @@
   margin: 0;
   color: #111827;
 
-  @media (prefers-color-scheme: dark) {
+  [data-theme="dark"] & {
     color: #f3f4f6;
   }
 }
@@ -323,7 +323,7 @@
   position: relative;
   padding-right: 5rem; // Space for status badge
 
-  @media (prefers-color-scheme: dark) {
+  [data-theme="dark"] & {
     background: #374151;
   }
 }
@@ -336,7 +336,7 @@
   word-wrap: break-word;
   overflow-wrap: break-word;
 
-  @media (prefers-color-scheme: dark) {
+  [data-theme="dark"] & {
     color: #f3f4f6;
   }
 }
@@ -433,7 +433,7 @@
     padding: 2rem;
     overflow: visible; // Ensure overflow is visible in fullscreen
 
-    @media (prefers-color-scheme: dark) {
+    [data-theme="dark"] & {
       background: #111827;
     }
 
@@ -520,7 +520,7 @@
     box-shadow: 0 0 0 3px rgba(0, 160, 220, 0.1);
   }
 
-  @media (prefers-color-scheme: dark) {
+  [data-theme="dark"] & {
     background: #1f2937;
     border-color: #374151;
 

--- a/src/components/events/EventsWorldMap.tsx
+++ b/src/components/events/EventsWorldMap.tsx
@@ -326,7 +326,7 @@ export default function EventsWorldMap({
   return (
     <section className="events-world-map-wrapper">
       <h2 id="eventsWorldMapTitle" className="events-world-map-title">
-        Our events around the world
+        Events all around the world
       </h2>
 
       <div

--- a/src/components/home/constants.ts
+++ b/src/components/home/constants.ts
@@ -1,0 +1,2 @@
+/** Number of testimonials to display on the home page */
+export const HOME_TESTIMONIALS_COUNT = 4

--- a/src/components/home/get.action.ts
+++ b/src/components/home/get.action.ts
@@ -4,6 +4,10 @@ import { restQuery, normalizeEntity } from "@/libs/strapi-client"
 import { homePopulate, eventItemPopulate } from "@/libs/strapi-populate"
 import { getTestimonials } from "@/components/events/get.action"
 import { Testimonial } from "@/models/strapi"
+import { shuffleArray } from "@/libs/arrays"
+
+/** Number of testimonials to display on the home page */
+export const HOME_TESTIMONIALS_COUNT = 4
 
 // Types - will be replaced by OpenAPI generated types when available
 interface UploadFile {
@@ -88,28 +92,29 @@ export async function getExpectations(type: string) {
  * Shuffles server-side on each render (respects page revalidate cache)
  * Filters to only text testimonials with named authors (excludes audio and anonymous)
  */
-export async function getRandomTestimonials(count: number = 4) {
-  const allTestimonials = (await getTestimonials()) as Testimonial[]
+export async function getRandomTestimonials(
+  count: number = HOME_TESTIMONIALS_COUNT,
+) {
+  try {
+    const allTestimonials = await getTestimonials()
 
-  if (!allTestimonials || allTestimonials.length === 0) {
+    if (!allTestimonials || allTestimonials.length === 0) {
+      return []
+    }
+
+    // Filter to only text testimonials (no audio) with named authors
+    const textTestimonials = allTestimonials.filter(
+      (testimonial) => !testimonial.audio && testimonial.author,
+    )
+
+    if (textTestimonials.length === 0) {
+      return []
+    }
+
+    // Shuffle and return requested count
+    return shuffleArray(textTestimonials).slice(0, count)
+  } catch (error) {
+    console.error("Failed to fetch random testimonials:", error)
     return []
   }
-
-  // Filter to only text testimonials (no audio) with named authors
-  const textTestimonials = allTestimonials.filter(
-    (testimonial) => !testimonial.audio && testimonial.author,
-  )
-
-  if (textTestimonials.length === 0) {
-    return []
-  }
-
-  // Fisher-Yates shuffle
-  const shuffled = [...textTestimonials]
-  for (let i = shuffled.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1))
-    ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
-  }
-
-  return shuffled.slice(0, count)
 }

--- a/src/components/home/get.action.ts
+++ b/src/components/home/get.action.ts
@@ -5,9 +5,7 @@ import { homePopulate, eventItemPopulate } from "@/libs/strapi-populate"
 import { getTestimonials } from "@/components/events/get.action"
 import { Testimonial } from "@/models/strapi"
 import { shuffleArray } from "@/libs/arrays"
-
-/** Number of testimonials to display on the home page */
-export const HOME_TESTIMONIALS_COUNT = 4
+import { HOME_TESTIMONIALS_COUNT } from "./constants"
 
 // Types - will be replaced by OpenAPI generated types when available
 interface UploadFile {

--- a/src/components/home/get.action.ts
+++ b/src/components/home/get.action.ts
@@ -2,6 +2,8 @@
 
 import { restQuery, normalizeEntity } from "@/libs/strapi-client"
 import { homePopulate, eventItemPopulate } from "@/libs/strapi-populate"
+import { getTestimonials } from "@/components/events/get.action"
+import { Testimonial } from "@/models/strapi"
 
 // Types - will be replaced by OpenAPI generated types when available
 interface UploadFile {
@@ -79,4 +81,35 @@ export async function getExpectations(type: string) {
     },
   })
   return response.data || []
+}
+
+/**
+ * Get random testimonials for home page
+ * Shuffles server-side on each render (respects page revalidate cache)
+ * Filters to only text testimonials with named authors (excludes audio and anonymous)
+ */
+export async function getRandomTestimonials(count: number = 4) {
+  const allTestimonials = (await getTestimonials()) as Testimonial[]
+
+  if (!allTestimonials || allTestimonials.length === 0) {
+    return []
+  }
+
+  // Filter to only text testimonials (no audio) with named authors
+  const textTestimonials = allTestimonials.filter(
+    (testimonial) => !testimonial.audio && testimonial.author,
+  )
+
+  if (textTestimonials.length === 0) {
+    return []
+  }
+
+  // Fisher-Yates shuffle
+  const shuffled = [...textTestimonials]
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+  }
+
+  return shuffled.slice(0, count)
 }

--- a/src/components/home/testimonials-refresh.tsx
+++ b/src/components/home/testimonials-refresh.tsx
@@ -1,0 +1,169 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { Testimonial } from "@/models/strapi"
+import TestimonialItem from "@/components/events/testimonial"
+import { getRandomTestimonials } from "./get.action"
+
+interface TestimonialsRefreshProps {
+  initialTestimonials: Testimonial[]
+}
+
+const TestimonialsRefresh = ({
+  initialTestimonials,
+}: TestimonialsRefreshProps) => {
+  const [testimonials, setTestimonials] = useState(initialTestimonials)
+  const [isPending, startTransition] = useTransition()
+
+  const handleRefresh = () => {
+    startTransition(async () => {
+      const newTestimonials = await getRandomTestimonials(4)
+      setTestimonials(newTestimonials)
+    })
+  }
+
+  return (
+    <>
+      <div
+        className="testimonials-area pt-70 pb-70 bg-f1f8fb"
+        style={{ position: "relative" }}
+      >
+        <button
+          onClick={handleRefresh}
+          disabled={isPending}
+          className="testimonials-refresh-button"
+          aria-label="Show different testimonials"
+          title="Show different testimonials"
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            style={{
+              animation: isPending ? "spin 1s linear infinite" : "none",
+            }}
+          >
+            <polyline points="23 4 23 10 17 10" />
+            <polyline points="1 20 1 14 7 14" />
+            <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+          </svg>
+        </button>
+
+        <div className="container">
+          <div className="row">
+            {testimonials.map((testimonial) => (
+              <TestimonialItem
+                key={testimonial.documentId}
+                testimonial={testimonial}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+      <style jsx>{`
+        @keyframes spin {
+          from {
+            transform: rotate(0deg);
+          }
+          to {
+            transform: rotate(360deg);
+          }
+        }
+
+        .testimonials-refresh-button {
+          position: absolute;
+          top: 1rem;
+          right: 1rem;
+          z-index: 10;
+          width: 40px;
+          height: 40px;
+          background: white;
+          border: 2px solid #e5e7eb;
+          border-radius: 0.5rem;
+          cursor: pointer;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          transition: all 0.2s ease;
+          padding: 0;
+          box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+
+        .testimonials-refresh-button svg {
+          color: #111827;
+          transition: color 0.2s ease;
+        }
+
+        .testimonials-refresh-button:hover {
+          background: #f3f4f6;
+          border-color: #00a0dc;
+        }
+
+        .testimonials-refresh-button:hover svg {
+          color: #00a0dc;
+        }
+
+        .testimonials-refresh-button:active {
+          transform: scale(0.95);
+        }
+
+        .testimonials-refresh-button:focus {
+          outline: none;
+          border-color: #00a0dc;
+          box-shadow: 0 0 0 3px rgba(0, 160, 220, 0.1);
+        }
+
+        .testimonials-refresh-button:disabled {
+          cursor: not-allowed;
+          opacity: 0.6;
+        }
+
+        .testimonials-refresh-button:disabled:hover {
+          background: white;
+          border-color: #e5e7eb;
+        }
+
+        .testimonials-refresh-button:disabled:hover svg {
+          color: #111827;
+        }
+
+        :global([data-theme="dark"]) .testimonials-refresh-button {
+          background: #1f2937;
+          border-color: #374151;
+        }
+
+        :global([data-theme="dark"]) .testimonials-refresh-button svg {
+          color: #f3f4f6;
+        }
+
+        :global([data-theme="dark"]) .testimonials-refresh-button:hover {
+          background: #374151;
+          border-color: #00a0dc;
+        }
+
+        :global([data-theme="dark"]) .testimonials-refresh-button:hover svg {
+          color: #00a0dc;
+        }
+
+        :global([data-theme="dark"])
+          .testimonials-refresh-button:disabled:hover {
+          background: #1f2937;
+          border-color: #374151;
+        }
+
+        :global([data-theme="dark"])
+          .testimonials-refresh-button:disabled:hover
+          svg {
+          color: #f3f4f6;
+        }
+      `}</style>
+    </>
+  )
+}
+
+export default TestimonialsRefresh

--- a/src/components/home/testimonials-refresh.tsx
+++ b/src/components/home/testimonials-refresh.tsx
@@ -3,7 +3,8 @@
 import { useState, useTransition } from "react"
 import { Testimonial } from "@/models/strapi"
 import TestimonialItem from "@/components/events/testimonial"
-import { getRandomTestimonials, HOME_TESTIMONIALS_COUNT } from "./get.action"
+import { getRandomTestimonials } from "./get.action"
+import { HOME_TESTIMONIALS_COUNT } from "./constants"
 
 interface TestimonialsRefreshProps {
   initialTestimonials: Testimonial[]

--- a/src/components/home/testimonials-refresh.tsx
+++ b/src/components/home/testimonials-refresh.tsx
@@ -3,7 +3,7 @@
 import { useState, useTransition } from "react"
 import { Testimonial } from "@/models/strapi"
 import TestimonialItem from "@/components/events/testimonial"
-import { getRandomTestimonials } from "./get.action"
+import { getRandomTestimonials, HOME_TESTIMONIALS_COUNT } from "./get.action"
 
 interface TestimonialsRefreshProps {
   initialTestimonials: Testimonial[]
@@ -17,8 +17,17 @@ const TestimonialsRefresh = ({
 
   const handleRefresh = () => {
     startTransition(async () => {
-      const newTestimonials = await getRandomTestimonials(4)
-      setTestimonials(newTestimonials)
+      try {
+        const newTestimonials = await getRandomTestimonials(
+          HOME_TESTIMONIALS_COUNT,
+        )
+        if (newTestimonials.length > 0) {
+          setTestimonials(newTestimonials)
+        }
+      } catch (error) {
+        console.error("Failed to refresh testimonials:", error)
+        // Keep existing testimonials on error
+      }
     })
   }
 

--- a/src/components/home/testimonials.tsx
+++ b/src/components/home/testimonials.tsx
@@ -1,0 +1,32 @@
+import { getRandomTestimonials } from "./get.action"
+import TestimonialsRefresh from "./testimonials-refresh"
+import Link from "next/link"
+
+const HomeTestimonials = async () => {
+  const testimonials = await getRandomTestimonials(4)
+
+  if (!testimonials || testimonials.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="pt-100">
+      <h3 className="pb-3">What our community says</h3>
+      <p>
+        Hear from members of the #play14 community about their experiences.
+        These testimonials capture the spirit, impact, and joy of our events
+        around the world.
+      </p>
+
+      <TestimonialsRefresh initialTestimonials={testimonials} />
+
+      <div className="d-flex justify-content-center pb-70 pt-70">
+        <Link href="/events/testimonials" className="default-btn">
+          View all testimonials
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+export default HomeTestimonials

--- a/src/components/home/upcoming.tsx
+++ b/src/components/home/upcoming.tsx
@@ -9,7 +9,7 @@ const UpcomingEvents = async () => {
 
   return (
     <div className="pt-100">
-      <h3 className="pb-3">Get involved</h3>
+      <h3 className="pb-3">Our upcoming events</h3>
       <p>
         Ready to play? Join our <strong>upcoming events</strong> and be part of
         a vibrant community that’s shaping the future through play. Your next

--- a/src/libs/arrays.ts
+++ b/src/libs/arrays.ts
@@ -1,3 +1,17 @@
 export function deduplicate<T>(...arrays: T[][]) {
   return [...new Set(arrays.flat())]
 }
+
+/**
+ * Shuffles an array using the Fisher-Yates algorithm
+ * @param array - The array to shuffle
+ * @returns A new shuffled array (original array is not modified)
+ */
+export function shuffleArray<T>(array: T[]): T[] {
+  const shuffled = [...array]
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+  }
+  return shuffled
+}


### PR DESCRIPTION
## Summary
Adds a new testimonials section to the home page displaying 4 randomly selected testimonials with a refresh button to load different testimonials without page reload.

## Changes
- **New Components:**
  - `HomeTestimonials` - Server component that fetches initial testimonials
  - `TestimonialsRefresh` - Client component with refresh functionality and state management
  
- **Server Actions:**
  - `getRandomTestimonials()` - Fetches and randomizes testimonials using Fisher-Yates shuffle
  - Filters to only text testimonials with named authors (excludes audio and anonymous)
  
- **UI Features:**
  - Refresh button positioned in top-right corner matching WorldMap controls
  - Smooth transitions with React useTransition hook
  - Spinning icon animation during refresh
  - "View all testimonials" link with proper spacing
  
- **Theme Support:**
  - Fixed all components to use `[data-theme="dark"]` selector instead of `@media (prefers-color-scheme: dark)`
  - Updated `EventsWorldMap.scss` for consistent theme handling
  - Light mode: white buttons with dark icons
  - Dark mode: dark buttons with light icons

## Test Plan
- [ ] Verify testimonials display correctly on home page
- [ ] Test refresh button loads different testimonials
- [ ] Check button styling in both light and dark modes
- [ ] Verify theme switching works correctly
- [ ] Confirm only text testimonials with authors are shown
- [ ] Test "View all testimonials" link navigation